### PR TITLE
feat: acesso a campos via item["key"] para evitar colisão com métodos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ Todas as mudanças relevantes do DynoLayer serão documentadas neste arquivo.
 
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e o projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR/).
 
+## [1.2.0] - 2026-04-11
+
+### Added
+
+- **Acesso via dicionário (`item["key"]`)**: Implementa `__getitem__`, `__setitem__`, `__contains__` e `__delitem__` na classe `DynoLayer`. Permite acessar campos do registro sem colisão com métodos internos como `data`, `save`, `get`, etc.
+
+### Changed
+
+- **Reordenação dos parâmetros do `__init__`**: Os parâmetros mais usados (`entity`, `required_fields`, `timestamps`, `partition_key`) agora vêm primeiro, seguidos dos menos comuns (`fillable`, `timestamp_format`, `auto_id`, `auto_id_length`, `auto_id_table`, `sort_key`).
+- **Tipagem nos parâmetros `timestamp_format` e `auto_id`**: Agora usam `Literal` para autocomplete e validação estática.
+
 ## [1.1.0] - 2026-04-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Uma biblioteca Python para DynamoDB que traz a elegância do Eloquent ORM (Larav
 - **Escrita Condicional**: `unique=True` no create e condições no save para escrita segura
 - **Transações**: Escrita e leitura transacional atômica via `transact_write`/`transact_get`
 - **Configuração Centralizada**: API de configuração para credenciais AWS, timestamps e retry
+- **Acesso via Dicionário**: `item["key"]` para acessar campos sem colisão com métodos internos
 - **Type Safety**: Conversão automática de tipos e resolução inteligente de key conditions
 
 ## Instalação
@@ -133,6 +134,28 @@ recent_admins = (
 user = User.find({"id": 1})
 user.name = "Jane Doe"
 user.save()
+```
+
+### Acesso via Dicionário
+
+Use a sintaxe `item["key"]` para acessar campos cujo nome colide com métodos da classe (como `data`, `get`, `save`, etc):
+
+```python
+user = User.find({"id": 1})
+
+# Acesso por atributo — funciona para campos sem colisão
+print(user.name)           # "John Doe"
+
+# Acesso por dicionário — seguro para qualquer campo
+print(user["name"])        # "John Doe"
+user["name"] = "Jane Doe"  # Equivalente a user.name = "Jane Doe"
+
+# Verificar se um campo existe
+if "email" in user:
+    print(user["email"])
+
+# Deletar um campo
+del user["role"]
 ```
 
 ### Deletar Registros
@@ -424,6 +447,16 @@ count = User().get_count()
 | `fillable()` | Obter lista de campos preenchíveis |
 | `last_evaluated_key()` | Token de paginação da última query |
 | `get_count()` | Contagem de itens retornados na última query |
+
+### Acesso a Campos
+
+| Sintaxe | Descrição |
+|---------|-----------|
+| `item.campo` | Acesso por atributo (pode colidir com métodos) |
+| `item["campo"]` | Acesso por dicionário (seguro, sem colisão) |
+| `item["campo"] = valor` | Atribuição por dicionário |
+| `"campo" in item` | Verifica se o campo existe |
+| `del item["campo"]` | Remove o campo |
 
 ### Métodos da Collection
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -739,6 +739,51 @@ for user in User.where("role", "admin").index("role-index").stream():
     send_notification(user)
 ```
 
+## Acesso a Campos via Dicionário
+
+O DynoLayer usa `__getattr__`/`__setattr__` para expor campos do DynamoDB como propriedades do objeto. Isso funciona na maioria dos casos, mas causa colisão quando o nome de um campo coincide com um método da classe.
+
+### O problema
+
+```python
+user = User.find({"id": 1})
+user.data       # → <bound method DynoLayer.data>  (método, não o campo!)
+user.data()     # → {"id": 1, "data": "valor real", ...}
+```
+
+O Python resolve métodos definidos na classe **antes** de chamar `__getattr__`, então campos com nomes como `data`, `save`, `get`, `count`, `index`, `limit`, `stream`, `offset`, entre outros, ficam inacessíveis via acesso direto por atributo.
+
+### A solução: sintaxe de dicionário
+
+Use `item["key"]` para acessar qualquer campo de forma segura:
+
+```python
+user = User.find({"id": 1})
+
+# Acesso seguro — nunca colide com métodos
+user["data"]           # → valor do campo "data"
+user["save"]           # → valor do campo "save"
+
+# Atribuição
+user["name"] = "Ana"   # Equivalente a user.name = "Ana"
+
+# Verificar existência
+if "email" in user:
+    print(user["email"])
+
+# Deletar campo
+del user["role"]
+```
+
+### Quando usar cada sintaxe
+
+| Sintaxe | Quando usar |
+|---------|-------------|
+| `user.name` | Campos com nomes que **não** colidem com métodos da classe |
+| `user["name"]` | Sempre seguro — especialmente quando o nome do campo é dinâmico ou pode colidir |
+
+Para código defensivo ou quando os nomes dos campos vêm de input externo, prefira sempre a sintaxe de dicionário.
+
 ## Boas Práticas
 
 ### Use índices nas suas queries

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -205,7 +205,13 @@ user = User.find({"id": 1}, attributes=["name", "email"])
 user = User.find({"id": 1})
 user.name = "Jane Doe"
 user.save()
+
+# Também funciona com sintaxe de dicionário
+user["name"] = "Jane Doe"
+user.save()
 ```
+
+> **Dica**: Use `user["campo"]` quando o nome do campo pode colidir com métodos da classe (como `data`, `get`, `save`). Veja [Acesso a Campos via Dicionário](advanced.md#acesso-a-campos-via-dicionário) para mais detalhes.
 
 ### Deletar um registro
 

--- a/dynolayer/dynolayer.py
+++ b/dynolayer/dynolayer.py
@@ -44,9 +44,10 @@ class DynoLayer(CrudMixin):
     raise_on_error = True
     _class_last_error = None
 
-    def __init__(self, entity="", required_fields=None, fillable=None, timestamps=True, timestamp_format=None,
-                 auto_id=None, auto_id_length=None, auto_id_table=None,
-                 partition_key: str = "", sort_key: str = None):
+    def __init__(self, entity="", required_fields=None, timestamps=True, partition_key: str = "",
+                 fillable=None, timestamp_format: Literal["numeric", "iso"] = None,
+                 auto_id: Literal["uuid4", "uuid1", "uuid7", "numeric"] = None,
+                 auto_id_length=None, auto_id_table=None, sort_key: str = None):
         if auto_id is not None:
             if auto_id not in self._VALID_AUTO_ID_STRATEGIES:
                 raise InvalidArgumentException(
@@ -124,6 +125,18 @@ class DynoLayer(CrudMixin):
             super().__setattr__(key, value)
         else:
             self._data[key] = value
+
+    def __getitem__(self, key):
+        return self._data[key]
+
+    def __setitem__(self, key, value):
+        self._data[key] = value
+
+    def __contains__(self, key):
+        return key in self._data
+
+    def __delitem__(self, key):
+        del self._data[key]
 
     @classmethod
     def configure(cls, **kwargs) -> None:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as file:
 
 setup(
     name='dynolayer',
-    version='1.1.0',
+    version='1.2.0',
     license='MIT License',
     packages=['dynolayer'],
     install_requires=[],

--- a/tests/unit/test_item_access.py
+++ b/tests/unit/test_item_access.py
@@ -1,0 +1,71 @@
+import pytest
+
+
+class TestGetItem:
+    def test_returns_field_value(self, get_user, create_table, aws_mock):
+        user = get_user.create({
+            "id": 1, "first_name": "Ana", "email": "ana@mail.com", "role": "admin",
+        })
+        assert user["first_name"] == "Ana"
+
+    def test_raises_key_error_for_missing_key(self, get_user, create_table, aws_mock):
+        user = get_user.create({
+            "id": 1, "first_name": "Ana", "email": "ana@mail.com", "role": "admin",
+        })
+        with pytest.raises(KeyError):
+            _ = user["nonexistent"]
+
+    def test_accessing_field_that_collides_with_method(self, get_user, create_table, aws_mock):
+        user = get_user.create({
+            "id": 1, "first_name": "Ana", "email": "ana@mail.com", "role": "admin",
+        })
+        result = user.data()
+        assert "data" not in result
+
+        user._data["data"] = "campo real"
+        assert user["data"] == "campo real"
+        assert callable(user.data)
+
+
+class TestSetItem:
+    def test_sets_field_value(self, get_user):
+        user = get_user()
+        user["first_name"] = "Carlos"
+        assert user._data["first_name"] == "Carlos"
+
+    def test_overwrites_existing_field(self, get_user, create_table, aws_mock):
+        user = get_user.create({
+            "id": 1, "first_name": "Ana", "email": "ana@mail.com", "role": "admin",
+        })
+        user["first_name"] = "Bia"
+        assert user["first_name"] == "Bia"
+
+
+class TestContains:
+    def test_returns_true_for_existing_key(self, get_user, create_table, aws_mock):
+        user = get_user.create({
+            "id": 1, "first_name": "Ana", "email": "ana@mail.com", "role": "admin",
+        })
+        assert "first_name" in user
+
+    def test_returns_false_for_missing_key(self, get_user, create_table, aws_mock):
+        user = get_user.create({
+            "id": 1, "first_name": "Ana", "email": "ana@mail.com", "role": "admin",
+        })
+        assert "nonexistent" not in user
+
+
+class TestDelItem:
+    def test_deletes_field(self, get_user, create_table, aws_mock):
+        user = get_user.create({
+            "id": 1, "first_name": "Ana", "email": "ana@mail.com", "role": "admin",
+        })
+        del user["first_name"]
+        assert "first_name" not in user
+
+    def test_raises_key_error_for_missing_key(self, get_user, create_table, aws_mock):
+        user = get_user.create({
+            "id": 1, "first_name": "Ana", "email": "ana@mail.com", "role": "admin",
+        })
+        with pytest.raises(KeyError):
+            del user["nonexistent"]


### PR DESCRIPTION
## Summary
- Implementa `__getitem__`, `__setitem__`, `__contains__` e `__delitem__` na classe `DynoLayer`, permitindo acesso seguro a campos via sintaxe de dicionário (`item["key"]`)
- Reordena parâmetros do `__init__` para priorizar os mais usados (`entity`, `required_fields`, `timestamps`, `partition_key`)
- Adiciona tipagem `Literal` nos parâmetros `timestamp_format` e `auto_id` para autocomplete e validação estática
- Atualiza documentação (README, getting-started, advanced) e CHANGELOG para v1.2.0

## Test plan
- [x] 9 testes unitários em `tests/unit/test_item_access.py` cobrindo todos os cenários
- [x] Teste de colisão: `user["data"]` retorna o campo, `user.data` retorna o método
- [x] Suite completa: 183 testes passando

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)