### PR TITLE
feat: método find(expression) unificado e rename find → get_item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ Todas as mudanças relevantes do DynoLayer serão documentadas neste arquivo.
 
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e o projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR/).
 
+## [1.3.0] - 2026-04-12
+
+### Breaking Changes
+
+- **`find(dict)` renomeado para `get_item(dict)`**: O classmethod `find` que buscava um item por chave primária foi renomeado para `get_item`. O método `find_or_fail` continua funcionando normalmente (chama `get_item` internamente).
+
+### Added
+
+- **Método `find(expression, **values)`**: Novo método de instância que unifica query e scan com uma API expressiva baseada em expression strings. Suporta todos os operadores de condição (`=`, `<>`, `<`, `<=`, `>`, `>=`, `begins_with`, `contains`, `in`, `between`, `exists`, `not_exists`, `attribute_type`) e conectores lógicos (`AND`, `OR`, `AND NOT`, `OR NOT`).
+- **`parse_expression()` em `utils.py`**: Parser de expression strings que tokeniza e valida a sintaxe, resolvendo placeholders (`:nome`) para os valores passados via kwargs.
+
+### Exemplos de migração
+
+```python
+# Antes (v1.2.x)
+user = User.find({"id": 1})
+users = User().and_where("role", "admin").index("role-index").fetch(True)
+
+# Depois (v1.3.0)
+user = User.get_item({"id": 1})
+users = User().find("role = :r", r="admin").index("role-index").fetch(True)
+```
+
 ## [1.2.0] - 2026-04-11
 
 ### Added
@@ -26,7 +49,7 @@ O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e o 
 
 | Método | Retorno em caso de erro |
 |--------|------------------------|
-| `find()` | `None` |
+| `get_item()` | `None` |
 | `create()` | `None` |
 | `delete()` | `False` |
 | `find_or_fail()` | `None` |

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Uma biblioteca Python para DynamoDB que traz a elegância do Eloquent ORM (Larav
 
 - **Active Record Pattern**: Defina models que representam tabelas DynamoDB
 - **Fluent Query Builder**: Encadeie métodos para construir queries complexas
+- **Expression Queries**: API expressiva com `find("attr = :val", val=x)` para queries e scans unificados
 - **Collections**: Trabalhe com resultados usando métodos similares ao Eloquent
 - **Timestamps Automáticos**: Gerenciamento opcional de `created_at` e `updated_at` (numérico ou ISO 8601)
 - **Proteção de Mass Assignment**: Whitelist de campos para prevenir dados indesejados
@@ -105,25 +106,34 @@ users = User.batch_create([
 users = User.all().get()
 
 # Buscar por chave primária
-user = User.find({"id": 1})
+user = User.get_item({"id": 1})
 
 # Buscar vários por chave primária (batch)
 users = User.batch_find([{"id": 1}, {"id": 2}, {"id": 3}])
 
-# Query com condições
+# Query com expression string (recomendado)
+admins = (
+    User().find("role = :r AND status = :s", r="admin", s="active")
+    .index("role-index")
+    .fetch(True)
+)
+
+# Queries complexas com expression
+recent_admins = (
+    User().find(
+        "role = :r AND created_at between :start and :end AND NOT email contains :e",
+        r="admin", start=yesterday, end=today, e="test"
+    )
+    .index("role-index")
+    .limit(100)
+    .fetch(True)
+)
+
+# Query com where (também suportado)
 admins = (
     User.where("role", "admin")
     .and_where("status", "active")
     .index("role-index")
-    .get()
-)
-
-# Queries complexas
-recent_admins = (
-    User.where("role", "admin")
-    .where_between("created_at", yesterday, today)
-    .where_not("email", "contains", "test")
-    .limit(100)
     .get()
 )
 ```
@@ -131,7 +141,7 @@ recent_admins = (
 ### Atualizar Registros
 
 ```python
-user = User.find({"id": 1})
+user = User.get_item({"id": 1})
 user.name = "Jane Doe"
 user.save()
 ```
@@ -141,7 +151,7 @@ user.save()
 Use a sintaxe `item["key"]` para acessar campos cujo nome colide com métodos da classe (como `data`, `get`, `save`, etc):
 
 ```python
-user = User.find({"id": 1})
+user = User.get_item({"id": 1})
 
 # Acesso por atributo — funciona para campos sem colisão
 print(user.name)           # "John Doe"
@@ -162,7 +172,7 @@ del user["role"]
 
 ```python
 # Deletar instância
-user = User.find({"id": 1})
+user = User.get_item({"id": 1})
 user.destroy()
 
 # Ou deletar por chave
@@ -403,8 +413,8 @@ count = User().get_count()
 | Método | Descrição |
 |--------|-----------|
 | `all()` | Iniciar query para todos os registros |
-| `find(key)` | Buscar registro por chave primária |
-| `find_or_fail(key, message)` | Buscar ou lançar exceção |
+| `get_item(key)` | Buscar registro por chave primária |
+| `find_or_fail(key, message)` | Buscar ou lançar exceção (usa `get_item` internamente) |
 | `where(*args)` | Iniciar query builder |
 | `create(data, unique)` | Criar e salvar registro (`unique=True` previne sobrescrita) |
 | `delete(key)` | Deletar registro por chave |
@@ -421,6 +431,7 @@ count = User().get_count()
 
 | Método | Descrição |
 |--------|-----------|
+| `find(expression, **values)` | Query/scan unificado com expression string |
 | `where(attr, operator, value)` | Adicionar condição WHERE |
 | `and_where(attr, operator, value)` | Adicionar condição AND |
 | `or_where(attr, operator, value)` | Adicionar condição OR |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -187,7 +187,7 @@ users = User.batch_create([
 users = User.all().get()
 
 # Buscar por chave primária
-user = User.find({"id": 1})
+user = User.get_item({"id": 1})
 
 # Buscar ou lançar exceção
 user = User.find_or_fail({"id": 1}, "Usuário não encontrado")
@@ -196,13 +196,23 @@ user = User.find_or_fail({"id": 1}, "Usuário não encontrado")
 users = User.batch_find([{"id": 1}, {"id": 2}, {"id": 3}])
 
 # Buscar apenas campos específicos (projeção)
-user = User.find({"id": 1}, attributes=["name", "email"])
+user = User.get_item({"id": 1}, attributes=["name", "email"])
+
+# Query com expression string
+admins = (
+    User().find("role = :r", r="admin")
+    .index("role-index")
+    .fetch(True)
+)
+
+# Scan geral com find
+all_users = User().find().fetch(True)
 ```
 
 ### Atualizar um registro
 
 ```python
-user = User.find({"id": 1})
+user = User.get_item({"id": 1})
 user.name = "Jane Doe"
 user.save()
 
@@ -217,7 +227,7 @@ user.save()
 
 ```python
 # Deletar instância
-user = User.find({"id": 1})
+user = User.get_item({"id": 1})
 user.destroy()
 
 # Ou deletar por chave

--- a/docs/query-builder.md
+++ b/docs/query-builder.md
@@ -2,6 +2,83 @@
 
 DynoLayer provides a fluent, chainable query builder similar to Laravel's Eloquent. Build complex queries with an intuitive API.
 
+## Expression Queries (find)
+
+O método `find()` oferece uma API expressiva para construir queries e scans com expression strings:
+
+### Sintaxe básica
+
+```python
+# Scan geral (todos os registros)
+users = User().find().fetch(True)
+
+# Query por partition key
+users = User().find("role = :r", r="admin").index("role-index").fetch(True)
+
+# Múltiplas condições
+users = User().find(
+    "role = :r AND status = :s",
+    r="admin", s="active"
+).index("role-index").fetch(True)
+```
+
+### Operadores suportados
+
+| Operador | Sintaxe | Exemplo |
+|----------|---------|---------|
+| Igual | `attr = :val` | `"user_id = :uid"` |
+| Diferente | `attr <> :val` | `"status <> :s"` |
+| Menor que | `attr < :val` | `"age < :max"` |
+| Menor ou igual | `attr <= :val` | `"age <= :max"` |
+| Maior que | `attr > :val` | `"age > :min"` |
+| Maior ou igual | `attr >= :val` | `"age >= :min"` |
+| Começa com | `attr begins_with :val` | `"name begins_with :prefix"` |
+| Contém | `attr contains :val` | `"tags contains :tag"` |
+| Está em | `attr in :val` | `"status in :list"` (valor deve ser lista) |
+| Entre | `attr between :start and :end` | `"age between :min and :max"` |
+| Existe | `attr exists` | `"email exists"` (sem placeholder) |
+| Não existe | `attr not_exists` | `"phone not_exists"` (sem placeholder) |
+| Tipo do atributo | `attr attribute_type :val` | `"data attribute_type :t"` |
+
+### Conectores lógicos
+
+| Conector | Exemplo |
+|----------|---------|
+| `AND` | `"user_id = :uid AND status = :s"` |
+| `OR` | `"city = :c1 OR city = :c2"` |
+| `AND NOT` | `"user_id = :uid AND NOT status = :s"` |
+| `OR NOT` | `"user_id = :uid OR NOT archived = :a"` |
+
+### Exemplos completos
+
+```python
+# Between
+orders = Order().find(
+    "created_at between :start and :end",
+    start="2024-01-01", end="2024-12-31"
+).fetch(True)
+
+# Exists / Not exists (sem placeholder)
+users = User().find("email exists").fetch(True)
+users = User().find("phone not_exists").fetch(True)
+
+# Combinação complexa
+addresses = Address().find(
+    "user_id = :uid AND email exists AND NOT status = :s",
+    uid="123", s="deleted"
+).index("user-index").limit(50).fetch(True)
+
+# Com paginação
+page1 = User().find("role = :r", r="admin").index("role-index").limit(10).fetch()
+last_key = User().last_evaluated_key
+
+page2 = User().find("role = :r", r="admin").index("role-index").limit(10).offset(last_key).fetch()
+```
+
+## Where Query Builder
+
+O query builder com `where()` continua disponível para quem prefere a API encadeada:
+
 ## Basic Queries
 
 ### Simple where clause
@@ -232,6 +309,7 @@ print(f"Found {active_admins.count()} active admins")
 
 | Method | Description |
 |--------|-------------|
+| `find(expression, **values)` | Unified query/scan with expression string |
 | `where(attr, operator, value)` | Add WHERE condition |
 | `and_where(attr, operator, value)` | Add AND condition |
 | `or_where(attr, operator, value)` | Add OR condition |

--- a/docs/spec-find-v1.3.0.md
+++ b/docs/spec-find-v1.3.0.md
@@ -1,0 +1,344 @@
+# Spec: Método `find` — Query & Scan Unificado
+
+**Versão:** 1.3.0  
+**Status:** Proposta  
+**Data:** 2026-04-12
+
+---
+
+## Motivação
+
+Hoje, para fazer query/scan no dynolayer, é necessário encadear múltiplas chamadas:
+
+```python
+Address().and_where("user_id", user_id).index("user-index").fetch(True)
+```
+
+O objetivo é oferecer uma API mais expressiva e concisa com um único método `find`, que aceita uma expression string com placeholders e valores via kwargs:
+
+```python
+Address().find("user_id = :uid", uid=user_id).index("user-index").fetch(True)
+```
+
+---
+
+## Breaking Changes
+
+### `find(dict)` → `get_item(dict)`
+
+O método `find` atual (classmethod que faz `get_item` por chave primária) será renomeado para `get_item`.
+
+```python
+# Antes (v1.x)
+Address.find({"user_id": "123"})
+Address.find({"user_id": "123"}, attributes=["name", "city"])
+
+# Depois (v1.3.0)
+Address.get_item({"user_id": "123"})
+Address.get_item({"user_id": "123"}, attributes=["name", "city"])
+```
+
+### `find_or_fail`
+
+Passa a chamar `get_item` internamente. A assinatura pública não muda.
+
+### `find` deixa de ser classmethod
+
+O novo `find` é método de instância, exigindo `()` na classe:
+
+```python
+# Antes
+Address.find({"pk": "1"})
+
+# Depois
+Address().find("pk = :val", val="1").fetch()
+```
+
+---
+
+## API Pública
+
+### `get_item(key, attributes=None)` — classmethod
+
+Substitui o `find(dict)` antigo. Busca um item por chave primária exata via `GetItem`.
+
+```python
+@classmethod
+def get_item(cls, key: dict, attributes: List[str] = None) -> Optional[DynoLayer]
+```
+
+**Exemplos:**
+
+```python
+user = User.get_item({"user_id": "123"})
+user = User.get_item({"user_id": "123"}, attributes=["name", "email"])
+```
+
+---
+
+### `find(expression=None, /, **values)` — método de instância
+
+Método unificado para query e scan. Retorna `self` para chaining.
+
+```python
+def find(self, expression: str = None, /, **values) -> DynoLayer
+```
+
+**Comportamento:**
+
+| Chamada | Ação |
+|---|---|
+| `find()` | Scan geral (equivale ao `all()` atual) |
+| `find("attr = :val", val=x)` | Auto-detecta: query se `attr` é partition key, scan com filter caso contrário |
+| `find("attr = :val", val=x).index("gsi")` | Query no GSI se `attr` é key do index, senão filter no scan |
+
+**Fluxo interno:**
+1. Se `expression` é `None` → seta `_scan_all = True`, retorna `self`
+2. Parseia a expression → lista de `(operador_lógico, atributo, condição, valor)`
+3. Para cada condição, chama `__set_filter_expression` (que auto-detecta key vs filter)
+4. Retorna `self` para chaining com `.index()`, `.limit()`, `.offset()`, `.fetch()`, etc.
+
+---
+
+## Sintaxe da Expression
+
+### Formato geral
+
+```
+atributo operador :placeholder [CONECTOR atributo operador :placeholder ...]
+```
+
+Os `:placeholder` são mapeados para os `**kwargs` pelo nome (sem os dois pontos).
+
+---
+
+### Operadores de condição
+
+Todos os operadores já suportados pelo query builder são aceitos na expression:
+
+#### Key condition + Filter
+
+| Operador | Sintaxe | Exemplo |
+|---|---|---|
+| Igual | `attr = :val` | `"user_id = :uid"` |
+| Menor que | `attr < :val` | `"age < :max"` |
+| Menor ou igual | `attr <= :val` | `"age <= :max"` |
+| Maior que | `attr > :val` | `"age > :min"` |
+| Maior ou igual | `attr >= :val` | `"age >= :min"` |
+| Começa com | `attr begins_with :val` | `"name begins_with :prefix"` |
+| Entre | `attr between :start and :end` | `"age between :min and :max"` |
+
+#### Somente Filter (não válidos como key condition)
+
+| Operador | Sintaxe | Exemplo |
+|---|---|---|
+| Diferente | `attr <> :val` | `"status <> :s"` |
+| Contém | `attr contains :val` | `"tags contains :tag"` |
+| Está em | `attr in :val` | `"status in :list"` (valor deve ser lista) |
+| Existe | `attr exists` | `"email exists"` (sem placeholder) |
+| Não existe | `attr not_exists` | `"phone not_exists"` (sem placeholder) |
+| Tipo do atributo | `attr attribute_type :val` | `"data attribute_type :t"` |
+
+---
+
+### Conectores lógicos
+
+Usados para combinar múltiplas condições:
+
+| Conector | Equivalente atual | Exemplo |
+|---|---|---|
+| `AND` | `and_where()` | `"user_id = :uid AND status = :s"` |
+| `OR` | `or_where()` | `"city = :c1 OR city = :c2"` |
+| `AND NOT` | `where_not()` | `"user_id = :uid AND NOT status = :s"` |
+| `OR NOT` | `or_where_not()` | `"user_id = :uid OR NOT archived = :a"` |
+
+A primeira condição é sempre tratada como `AND` (condição base).
+
+> **Nota:** O `and` dentro de `between :start and :end` é parte do operador `between`, não um conector lógico. O parser trata isso automaticamente.
+
+---
+
+## Exemplos Completos
+
+### Scan geral
+
+```python
+# Todos os registros
+addresses = Address().find().fetch(True)
+```
+
+### Query por partition key
+
+```python
+# Auto-detecta que user_id é partition key → executa Query
+addresses = Address().find("user_id = :uid", uid="123").fetch(True)
+```
+
+### Query em GSI
+
+```python
+# Query no Global Secondary Index
+addresses = Address().find("city = :c", c="São Paulo").index("city-index").fetch(True)
+```
+
+### Scan com filter
+
+```python
+# city não é key da tabela → executa Scan com FilterExpression
+addresses = Address().find("city = :c", c="São Paulo").fetch(True)
+```
+
+### Múltiplas condições (AND)
+
+```python
+addresses = Address().find(
+    "user_id = :uid AND status = :s",
+    uid="123",
+    s="active"
+).fetch(True)
+```
+
+### OR
+
+```python
+addresses = Address().find(
+    "city = :c1 OR city = :c2",
+    c1="São Paulo",
+    c2="Rio de Janeiro"
+).fetch(True)
+```
+
+### AND NOT
+
+```python
+addresses = Address().find(
+    "user_id = :uid AND NOT status = :s",
+    uid="123",
+    s="deleted"
+).fetch(True)
+```
+
+### OR NOT
+
+```python
+addresses = Address().find(
+    "user_id = :uid OR NOT archived = :a",
+    uid="123",
+    a=True
+).fetch(True)
+```
+
+### Between
+
+```python
+orders = Order().find(
+    "created_at between :start and :end",
+    start="2024-01-01",
+    end="2024-12-31"
+).fetch(True)
+```
+
+### Begins with
+
+```python
+users = User().find("name begins_with :prefix", prefix="Jo").fetch(True)
+```
+
+### Contains
+
+```python
+posts = Post().find("tags contains :tag", tag="python").fetch(True)
+```
+
+### In (valor deve ser lista)
+
+```python
+users = User().find("status in :statuses", statuses=["active", "pending"]).fetch(True)
+```
+
+### Exists / Not exists
+
+```python
+# Sem placeholder — não precisa de kwargs
+users = User().find("email exists").fetch(True)
+users = User().find("phone not_exists").fetch(True)
+```
+
+### Combinações complexas
+
+```python
+addresses = Address().find(
+    "user_id = :uid AND email exists AND NOT status = :s",
+    uid="123",
+    s="deleted"
+).index("user-index").limit(50).fetch(True)
+```
+
+### Com paginação
+
+```python
+page1 = Address().find("user_id = :uid", uid="123").limit(10).fetch()
+last_key = page1.last_evaluated_key  # via instância que executou
+
+page2 = Address().find("user_id = :uid", uid="123").limit(10).offset(last_key).fetch()
+```
+
+---
+
+## Parser de Expressions
+
+### Nova função: `parse_expression(expression, **values)`
+
+**Localização:** `dynolayer/utils.py`
+
+**Entrada:**
+- `expression`: string com a expression (ex: `"user_id = :uid AND status = :s"`)
+- `**values`: kwargs com os valores dos placeholders
+
+**Saída:**
+Lista de tuplas: `(operador_lógico, atributo, operador_condição, valor)`
+
+**Algoritmo:**
+1. Tokenizar a expression, identificando primeiro padrões `between :x and :y` para proteger o `and` interno
+2. Split pelos conectores lógicos (`AND NOT`, `OR NOT`, `AND`, `OR`) — nesta ordem de prioridade para evitar ambiguidade
+3. Para cada fragmento, extrair via regex: `atributo`, `operador`, `:placeholder(s)`
+4. Resolver placeholders → valores dos kwargs
+5. Validar que todos os placeholders foram fornecidos
+
+**Erros:**
+- `InvalidArgumentException` se um placeholder não tem valor correspondente nos kwargs
+- `InvalidArgumentException` se a expression tem sintaxe inválida
+- `InvalidArgumentException` se `in` recebe valor que não é lista
+
+---
+
+## Alterações por Arquivo
+
+### `dynolayer/utils.py`
+
+- **Nova função:** `parse_expression(expression: str, **values) -> List[Tuple[str, str, str, Any]]`
+
+### `dynolayer/dynolayer.py`
+
+- **Novo classmethod:** `get_item(cls, key: dict, attributes: List[str] = None) -> Optional[DynoLayer]` — código do `find` atual
+- **Novo método de instância:** `find(self, expression: str = None, /, **values) -> DynoLayer`
+- **Alteração:** `find_or_fail` passa a chamar `get_item` em vez de `find`
+- **Remoção:** `find` classmethod antigo (substituído por `get_item`)
+
+### `dynolayer/__init__.py`
+
+- Exportar `get_item` se necessário
+
+### `tests/`
+
+- Testes para `get_item` (migração dos testes de `find(dict)` existentes)
+- Testes para `find()` sem args (scan all)
+- Testes para `find(expression)` com cada operador de condição
+- Testes para `find(expression)` com cada conector lógico
+- Testes para `find().index()` (query em GSI)
+- Testes para `parse_expression` (unit tests do parser)
+- Testes de erro: placeholder faltando, sintaxe inválida, `in` sem lista
+
+### `CHANGELOG.md`
+
+- Entrada para v1.3.0 com breaking changes documentados

--- a/dynolayer/dynolayer.py
+++ b/dynolayer/dynolayer.py
@@ -13,7 +13,7 @@ from dynolayer.crud_mixin import CrudMixin
 from dynolayer.exceptions import (
     DynoLayerException, QueryException, ValidationException, RecordNotFoundException,
     InvalidArgumentException, AutoIdException, )
-from dynolayer.utils import extract_params, transform_params_in_query, transform_params_in_filter, Collection
+from dynolayer.utils import extract_params, parse_expression, transform_params_in_query, transform_params_in_filter, Collection
 
 
 class _HybridWhere:
@@ -150,7 +150,7 @@ class DynoLayer(CrudMixin):
         return instance
 
     @classmethod
-    def find(cls, key: dict, attributes: List[str] = None) -> Optional[DynoLayer]:
+    def get_item(cls, key: dict, attributes: List[str] = None) -> Optional[DynoLayer]:
         cls._class_last_error = None
         try:
             instance = cls()
@@ -176,6 +176,17 @@ class DynoLayer(CrudMixin):
                 raise
             cls._class_last_error = e
             return None
+
+    def find(self, expression: str = None, /, **values) -> DynoLayer:
+        if expression is None:
+            self._scan_all = True
+            return self
+
+        parsed = parse_expression(expression, **values)
+        for connector, attribute, condition, value in parsed:
+            self.__set_filter_expression(attribute, condition, value, connector)
+
+        return self
 
     where = _HybridWhere()
     fail = _HybridFail()
@@ -646,7 +657,7 @@ class DynoLayer(CrudMixin):
     def find_or_fail(cls, key: dict, message="Record not found.", attributes: List[str] = None) -> Optional[DynoLayer]:
         cls._class_last_error = None
         try:
-            instance = cls.find(key, attributes=attributes)
+            instance = cls.get_item(key, attributes=attributes)
             if instance is None and cls._class_last_error is None:
                 raise RecordNotFoundException(message, key=key, entity=cls.__name__)
             return instance

--- a/dynolayer/utils.py
+++ b/dynolayer/utils.py
@@ -1,4 +1,5 @@
-from typing import Dict, Tuple, Literal, Union, List
+import re
+from typing import Any, Dict, Tuple, Literal, Union, List
 
 from boto3.dynamodb.conditions import Attr, Key, ConditionBase
 
@@ -25,6 +26,132 @@ class Collection:
 
     def __len__(self):
         return len(self._items)
+
+
+_BETWEEN_RE = re.compile(
+    r'(\w+)\s+between\s+:(\w+)\s+and\s+:(\w+)',
+    re.IGNORECASE,
+)
+_BETWEEN_PLACEHOLDER = '\x00BETWEEN\x00'
+
+_CONNECTOR_RE = re.compile(
+    r'\s+(AND\s+NOT|OR\s+NOT|AND|OR)\s+',
+)
+
+_CONDITION_RE = re.compile(
+    r'^(\w+)\s+(=|<>|<=|>=|<|>|begins_with|contains|in|attribute_type)\s+:(\w+)$'
+)
+
+_UNARY_RE = re.compile(
+    r'^(\w+)\s+(exists|not_exists)$'
+)
+
+_CONNECTOR_MAP = {
+    'AND': 'AND',
+    'OR': 'OR',
+    'AND NOT': 'AND_NOT',
+    'OR NOT': 'OR_NOT',
+}
+
+
+def parse_expression(expression: str, **values) -> List[Tuple[str, str, str, Any]]:
+    from dynolayer.exceptions import InvalidArgumentException
+
+    protected = []
+    expr = expression
+
+    for m in _BETWEEN_RE.finditer(expr):
+        attr, p1, p2 = m.group(1), m.group(2), m.group(3)
+        if p1 not in values:
+            raise InvalidArgumentException(
+                f"Missing value for placeholder ':{p1}'.",
+                method="find",
+                expected=f"kwarg '{p1}'",
+                received="not provided",
+            )
+        if p2 not in values:
+            raise InvalidArgumentException(
+                f"Missing value for placeholder ':{p2}'.",
+                method="find",
+                expected=f"kwarg '{p2}'",
+                received="not provided",
+            )
+        protected.append((attr, 'between', [values[p1], values[p2]]))
+        expr = expr.replace(m.group(0), _BETWEEN_PLACEHOLDER, 1)
+
+    parts = _CONNECTOR_RE.split(expr.strip())
+
+    results: List[Tuple[str, str, str, Any]] = []
+    between_idx = 0
+    connector = 'AND'
+
+    i = 0
+    while i < len(parts):
+        fragment = parts[i].strip()
+        if not fragment:
+            i += 1
+            continue
+
+        if fragment.upper() in _CONNECTOR_MAP:
+            connector = _CONNECTOR_MAP[fragment.upper()]
+            i += 1
+            continue
+
+        if _BETWEEN_PLACEHOLDER in fragment:
+            results.append((connector, *protected[between_idx]))
+            between_idx += 1
+            connector = 'AND'
+            i += 1
+            continue
+
+        unary_match = _UNARY_RE.match(fragment)
+        if unary_match:
+            attr = unary_match.group(1)
+            op = unary_match.group(2)
+            results.append((connector, attr, op, None))
+            connector = 'AND'
+            i += 1
+            continue
+
+        cond_match = _CONDITION_RE.match(fragment)
+        if cond_match:
+            attr = cond_match.group(1)
+            op = cond_match.group(2)
+            placeholder = cond_match.group(3)
+            if placeholder not in values:
+                raise InvalidArgumentException(
+                    f"Missing value for placeholder ':{placeholder}'.",
+                    method="find",
+                    expected=f"kwarg '{placeholder}'",
+                    received="not provided",
+                )
+            val = values[placeholder]
+            if op == 'in' and not isinstance(val, list):
+                raise InvalidArgumentException(
+                    f"Operator 'in' requires a list value for ':{placeholder}'.",
+                    method="find",
+                    expected="list",
+                    received=type(val).__name__,
+                )
+            results.append((connector, attr, op, val))
+            connector = 'AND'
+            i += 1
+            continue
+
+        raise InvalidArgumentException(
+            f"Invalid expression syntax: '{fragment}'.",
+            method="find",
+            expected="'attribute operator :placeholder' or 'attribute exists/not_exists'",
+            received=fragment,
+        )
+
+    if not results:
+        raise InvalidArgumentException(
+            "Empty or invalid expression.",
+            method="find",
+        )
+
+    return results
 
 
 def extract_params(*args):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as file:
 
 setup(
     name='dynolayer',
-    version='1.2.0',
+    version='1.3.0',
     license='MIT License',
     packages=['dynolayer'],
     install_requires=[],

--- a/tests/unit/test_auto_id.py
+++ b/tests/unit/test_auto_id.py
@@ -266,7 +266,7 @@ class TestAutoIdValidation:
 
 class TestAutoIdDisabled:
     def test_no_auto_id_by_default(self, get_user, create_table, aws_mock, save_records):
-        user = get_user.find({"id": 1})
+        user = get_user.get_item({"id": 1})
         assert user is not None
         assert user.id == 1
 

--- a/tests/unit/test_conditions.py
+++ b/tests/unit/test_conditions.py
@@ -30,7 +30,7 @@ class TestConditionalSave:
     def test_save_with_condition_succeeds(self, get_user, create_table, aws_mock):
         get_user.create({"id": 1, "first_name": "John", "email": "john@mail.com", "role": "admin"})
 
-        user = get_user.find({"id": 1})
+        user = get_user.get_item({"id": 1})
         user.first_name = "Jane"
         result = user.save(condition=Attr("role").eq("admin"))
         assert result is True
@@ -38,7 +38,7 @@ class TestConditionalSave:
     def test_save_with_condition_fails(self, get_user, create_table, aws_mock):
         get_user.create({"id": 1, "first_name": "John", "email": "john@mail.com", "role": "admin"})
 
-        user = get_user.find({"id": 1})
+        user = get_user.get_item({"id": 1})
         user.first_name = "Jane"
         with pytest.raises(ConditionalCheckException):
             user.save(condition=Attr("role").eq("moderator"))

--- a/tests/unit/test_declared_keys.py
+++ b/tests/unit/test_declared_keys.py
@@ -58,29 +58,29 @@ class TestDeclaredPartitionKey:
 
     def test_find_without_describe_table(self, get_fast_user, create_table, aws_mock):
         get_fast_user.create({"id": 1, "first_name": "John", "email": "john@mail.com", "role": "admin"})
-        user = get_fast_user.find({"id": 1})
+        user = get_fast_user.get_item({"id": 1})
         assert user.first_name == "John"
 
     def test_save_without_describe_table(self, get_fast_user, create_table, aws_mock):
         get_fast_user.create({"id": 1, "first_name": "John", "email": "john@mail.com", "role": "admin"})
-        user = get_fast_user.find({"id": 1})
+        user = get_fast_user.get_item({"id": 1})
         user.first_name = "Jane"
         user.save()
-        assert get_fast_user.find({"id": 1}).first_name == "Jane"
+        assert get_fast_user.get_item({"id": 1}).first_name == "Jane"
 
     def test_delete_without_describe_table(self, get_fast_user, create_table, aws_mock):
         get_fast_user.create({"id": 1, "first_name": "John", "email": "john@mail.com", "role": "admin"})
         get_fast_user.delete({"id": 1})
-        assert get_fast_user.find({"id": 1}) is None
+        assert get_fast_user.get_item({"id": 1}) is None
 
     def test_destroy_without_describe_table(self, get_fast_user, create_table, aws_mock):
         user = get_fast_user.create({"id": 1, "first_name": "John", "email": "john@mail.com", "role": "admin"})
         user.destroy()
-        assert get_fast_user.find({"id": 1}) is None
+        assert get_fast_user.get_item({"id": 1}) is None
 
     def test_validate_key_dict(self, get_fast_user, create_table, aws_mock):
         with pytest.raises(ValidationException, match="Missing primary key"):
-            get_fast_user.find({})
+            get_fast_user.get_item({})
 
     def test_index_query_lazy_loads_indexes(self, get_fast_user, create_table, aws_mock):
         get_fast_user.create({"id": 1, "first_name": "John", "email": "john@mail.com", "role": "admin"})
@@ -102,19 +102,19 @@ class TestDeclaredCompositeKey:
 
     def test_find_with_composite_key(self, get_event, create_table_with_sort_key, aws_mock):
         get_event.create({"user_id": "u1", "timestamp": 1000, "type": "login", "payload": "ok"})
-        event = get_event.find({"user_id": "u1", "timestamp": 1000})
+        event = get_event.get_item({"user_id": "u1", "timestamp": 1000})
         assert event.type == "login"
 
     def test_find_missing_sort_key_raises(self, get_event, create_table_with_sort_key, aws_mock):
         with pytest.raises(ValidationException, match="Missing primary key"):
-            get_event.find({"user_id": "u1"})
+            get_event.get_item({"user_id": "u1"})
 
     def test_save_with_composite_key(self, get_event, create_table_with_sort_key, aws_mock):
         get_event.create({"user_id": "u1", "timestamp": 1000, "type": "login", "payload": "ok"})
-        event = get_event.find({"user_id": "u1", "timestamp": 1000})
+        event = get_event.get_item({"user_id": "u1", "timestamp": 1000})
         event.payload = "updated"
         event.save()
-        assert get_event.find({"user_id": "u1", "timestamp": 1000}).payload == "updated"
+        assert get_event.get_item({"user_id": "u1", "timestamp": 1000}).payload == "updated"
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_destroy.py
+++ b/tests/unit/test_destroy.py
@@ -3,7 +3,7 @@ import pytest
 
 class TestRemoveRecords:
     def test_with_destroy_method(self, get_user, create_table, aws_mock, save_records):
-        user = get_user.find({"id": 5})
+        user = get_user.get_item({"id": 5})
         assert isinstance(user.first_name, str)
         assert user.destroy()
 

--- a/tests/unit/test_get_item.py
+++ b/tests/unit/test_get_item.py
@@ -1,0 +1,129 @@
+import pytest
+from dynolayer.utils import Collection
+from dynolayer.exceptions import ValidationException, RecordNotFoundException
+
+
+class TestGetItem:
+    def test_get_item_returns_record(self, get_user, create_table, aws_mock, save_records):
+        user = get_user.get_item({"id": 1})
+        assert user is not None
+        assert user.id == 1
+
+    def test_get_item_returns_none_for_missing(self, get_user, create_table, aws_mock):
+        user = get_user.get_item({"id": 999})
+        assert user is None
+
+    def test_get_item_with_attributes(self, get_user, create_table, aws_mock, save_records):
+        user = get_user.get_item({"id": 1}, attributes=["first_name", "email"])
+        assert user is not None
+        assert user.first_name is not None
+
+    def test_get_item_with_empty_key_raises(self, get_user, create_table, aws_mock):
+        with pytest.raises(ValidationException, match="Missing primary key"):
+            get_user.get_item({})
+
+
+class TestFindOrFailUsesGetItem:
+    def test_find_or_fail_returns_record(self, get_user, create_table, aws_mock, save_records):
+        user = get_user.find_or_fail({"id": 1})
+        assert user is not None
+        assert user.id == 1
+
+    def test_find_or_fail_raises_when_not_found(self, get_user, create_table, aws_mock):
+        with pytest.raises(RecordNotFoundException, match="Record not found"):
+            get_user.find_or_fail({"id": 999})
+
+
+class TestFindInstanceMethod:
+    def test_find_without_args_scan_all(self, get_user, create_table, aws_mock, save_records):
+        result = get_user().find().fetch(True)
+        assert isinstance(result, Collection)
+        assert result.count() == 20
+
+    def test_find_with_partition_key(self, get_user, create_table, aws_mock, save_records):
+        get_user().create({
+            "id": 500,
+            "role": "admin",
+            "first_name": "FindTest",
+            "email": "findtest@mail.com",
+        })
+
+        result = get_user().find("role = :r", r="admin").index("role-index").fetch(True)
+        assert isinstance(result, Collection)
+        assert result.count() >= 1
+
+    def test_find_with_multiple_conditions(self, get_user, create_table, aws_mock, save_records):
+        get_user().create({
+            "id": 600,
+            "role": "admin",
+            "first_name": "MultiTest",
+            "email": "multi@mail.com",
+            "stars": 5,
+        })
+
+        result = (
+            get_user()
+            .find("role = :r AND stars = :s", r="admin", s=5)
+            .index("role-index")
+            .fetch(True)
+        )
+        assert isinstance(result, Collection)
+
+    def test_find_with_begins_with(self, get_user, create_table, aws_mock, save_records):
+        get_user().create({
+            "id": 700,
+            "role": "admin",
+            "first_name": "BeginsTest",
+            "email": "begins.test@mail.com",
+        })
+
+        result = (
+            get_user()
+            .find("role = :r AND email begins_with :prefix", r="admin", prefix="begins")
+            .index("role-email-index")
+            .fetch(True)
+        )
+        assert isinstance(result, Collection)
+        assert result.count() >= 1
+        assert result.first().first_name == "BeginsTest"
+
+    def test_find_with_between(self, get_user, create_table, aws_mock, save_records):
+        from datetime import datetime, timedelta, timezone
+
+        get_user().create({
+            "id": 800,
+            "role": "admin",
+            "first_name": "BetweenTest",
+            "email": "between@mail.com",
+        })
+
+        ts_yesterday = int((datetime.now(timezone.utc) - timedelta(days=1)).timestamp())
+        ts_today = int(datetime.now(timezone.utc).timestamp())
+
+        result = (
+            get_user()
+            .find("role = :r AND created_at between :start and :end", r="admin", start=ts_yesterday, end=ts_today)
+            .index("role-index")
+            .fetch(True)
+        )
+        assert isinstance(result, Collection)
+        assert result.count() >= 1
+
+    def test_find_scan_with_filter(self, get_user, create_table, aws_mock, save_records):
+        result = get_user().find("stars = :s", s=3).force_scan().get(return_all=True)
+        assert isinstance(result, Collection)
+
+    def test_find_with_chaining(self, get_user, create_table, aws_mock, save_records):
+        result = (
+            get_user()
+            .find("role = :r", r="admin")
+            .index("role-index")
+            .limit(5)
+            .fetch()
+        )
+        assert isinstance(result, Collection)
+        assert result.count() <= 5
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/tests/unit/test_key_validation.py
+++ b/tests/unit/test_key_validation.py
@@ -3,12 +3,12 @@ from dynolayer.exceptions import ValidationException, QueryException
 
 
 class TestPrimaryKeyValidation:
-    def test_find_with_missing_key_raises(self, get_user, create_table, aws_mock):
+    def test_get_item_with_missing_key_raises(self, get_user, create_table, aws_mock):
         with pytest.raises(ValidationException, match="Missing primary key"):
-            get_user.find({})
+            get_user.get_item({})
 
-    def test_find_with_valid_key_passes(self, get_user, create_table, aws_mock, save_records):
-        user = get_user.find({"id": 1})
+    def test_get_item_with_valid_key_passes(self, get_user, create_table, aws_mock, save_records):
+        user = get_user.get_item({"id": 1})
         assert user is not None
 
     def test_delete_with_missing_key_raises(self, get_user, create_table, aws_mock):

--- a/tests/unit/test_parse_expression.py
+++ b/tests/unit/test_parse_expression.py
@@ -1,0 +1,155 @@
+import pytest
+from dynolayer.utils import parse_expression
+from dynolayer.exceptions import InvalidArgumentException
+
+
+class TestParseExpressionBasicOperators:
+    def test_equal(self):
+        result = parse_expression("user_id = :uid", uid="123")
+        assert result == [("AND", "user_id", "=", "123")]
+
+    def test_less_than(self):
+        result = parse_expression("age < :max", max=30)
+        assert result == [("AND", "age", "<", 30)]
+
+    def test_less_than_or_equal(self):
+        result = parse_expression("age <= :max", max=30)
+        assert result == [("AND", "age", "<=", 30)]
+
+    def test_greater_than(self):
+        result = parse_expression("age > :min", min=18)
+        assert result == [("AND", "age", ">", 18)]
+
+    def test_greater_than_or_equal(self):
+        result = parse_expression("age >= :min", min=18)
+        assert result == [("AND", "age", ">=", 18)]
+
+    def test_not_equal(self):
+        result = parse_expression("status <> :s", s="deleted")
+        assert result == [("AND", "status", "<>", "deleted")]
+
+    def test_begins_with(self):
+        result = parse_expression("name begins_with :prefix", prefix="Jo")
+        assert result == [("AND", "name", "begins_with", "Jo")]
+
+    def test_contains(self):
+        result = parse_expression("tags contains :tag", tag="python")
+        assert result == [("AND", "tags", "contains", "python")]
+
+    def test_in_operator(self):
+        result = parse_expression("status in :list", list=["active", "pending"])
+        assert result == [("AND", "status", "in", ["active", "pending"])]
+
+    def test_attribute_type(self):
+        result = parse_expression("data attribute_type :t", t="S")
+        assert result == [("AND", "data", "attribute_type", "S")]
+
+
+class TestParseExpressionBetween:
+    def test_between(self):
+        result = parse_expression("age between :min and :max", min=18, max=65)
+        assert result == [("AND", "age", "between", [18, 65])]
+
+    def test_between_with_strings(self):
+        result = parse_expression(
+            "created_at between :start and :end",
+            start="2024-01-01",
+            end="2024-12-31",
+        )
+        assert result == [("AND", "created_at", "between", ["2024-01-01", "2024-12-31"])]
+
+
+class TestParseExpressionUnary:
+    def test_exists(self):
+        result = parse_expression("email exists")
+        assert result == [("AND", "email", "exists", None)]
+
+    def test_not_exists(self):
+        result = parse_expression("phone not_exists")
+        assert result == [("AND", "phone", "not_exists", None)]
+
+
+class TestParseExpressionConnectors:
+    def test_and_connector(self):
+        result = parse_expression("user_id = :uid AND status = :s", uid="123", s="active")
+        assert result == [
+            ("AND", "user_id", "=", "123"),
+            ("AND", "status", "=", "active"),
+        ]
+
+    def test_or_connector(self):
+        result = parse_expression("city = :c1 OR city = :c2", c1="SP", c2="RJ")
+        assert result == [
+            ("AND", "city", "=", "SP"),
+            ("OR", "city", "=", "RJ"),
+        ]
+
+    def test_and_not_connector(self):
+        result = parse_expression("user_id = :uid AND NOT status = :s", uid="123", s="deleted")
+        assert result == [
+            ("AND", "user_id", "=", "123"),
+            ("AND_NOT", "status", "=", "deleted"),
+        ]
+
+    def test_or_not_connector(self):
+        result = parse_expression("user_id = :uid OR NOT archived = :a", uid="123", a=True)
+        assert result == [
+            ("AND", "user_id", "=", "123"),
+            ("OR_NOT", "archived", "=", True),
+        ]
+
+
+class TestParseExpressionComplex:
+    def test_multiple_conditions(self):
+        result = parse_expression(
+            "user_id = :uid AND email exists AND NOT status = :s",
+            uid="123",
+            s="deleted",
+        )
+        assert result == [
+            ("AND", "user_id", "=", "123"),
+            ("AND", "email", "exists", None),
+            ("AND_NOT", "status", "=", "deleted"),
+        ]
+
+    def test_between_with_and_connector(self):
+        result = parse_expression(
+            "user_id = :uid AND created_at between :start and :end",
+            uid="123",
+            start="2024-01-01",
+            end="2024-12-31",
+        )
+        assert result == [
+            ("AND", "user_id", "=", "123"),
+            ("AND", "created_at", "between", ["2024-01-01", "2024-12-31"]),
+        ]
+
+
+class TestParseExpressionErrors:
+    def test_missing_placeholder_value(self):
+        with pytest.raises(InvalidArgumentException, match="Missing value for placeholder"):
+            parse_expression("user_id = :uid")
+
+    def test_invalid_syntax(self):
+        with pytest.raises(InvalidArgumentException, match="Invalid expression syntax"):
+            parse_expression("invalid expression here", val="x")
+
+    def test_in_with_non_list_value(self):
+        with pytest.raises(InvalidArgumentException, match="requires a list"):
+            parse_expression("status in :s", s="active")
+
+    def test_empty_expression(self):
+        with pytest.raises(InvalidArgumentException, match="Empty or invalid"):
+            parse_expression("")
+
+    def test_between_missing_start_value(self):
+        with pytest.raises(InvalidArgumentException, match="Missing value for placeholder"):
+            parse_expression("age between :min and :max", max=65)
+
+    def test_between_missing_end_value(self):
+        with pytest.raises(InvalidArgumentException, match="Missing value for placeholder"):
+            parse_expression("age between :min and :max", min=18)
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/tests/unit/test_silent_mode.py
+++ b/tests/unit/test_silent_mode.py
@@ -8,10 +8,10 @@ from dynolayer.exceptions import (
 class TestSilentModeClassMethods:
     def test_find_with_invalid_key_raises_by_default(self, get_user, create_table, aws_mock):
         with pytest.raises(ValidationException):
-            get_user.find({})
+            get_user.get_item({})
 
     def test_find_with_invalid_key_silent(self, get_silent_user, create_table, aws_mock):
-        result = get_silent_user.find({})
+        result = get_silent_user.get_item({})
         assert result is None
         error = get_silent_user.fail()
         assert isinstance(error, ValidationException)
@@ -100,11 +100,11 @@ class TestSilentModeInstanceMethods:
 class TestSilentModeErrorReset:
     def test_fail_resets_on_successful_operation(self, get_silent_user, create_table, aws_mock):
         # First: trigger an error
-        get_silent_user.find({})
+        get_silent_user.get_item({})
         assert get_silent_user.fail() is not None
 
         # Second: successful operation resets the error
-        get_silent_user.find({"id": 1})
+        get_silent_user.get_item({"id": 1})
         assert get_silent_user.fail() is None
 
     def test_instance_fail_resets_on_successful_operation(self, get_silent_user, create_table, aws_mock):
@@ -145,7 +145,7 @@ class TestSilentModeSuccessfulOperations:
         assert user.fail() is None
 
     def test_find_returns_none_for_missing_record_no_error(self, get_silent_user, create_table, aws_mock):
-        result = get_silent_user.find({"id": 999})
+        result = get_silent_user.get_item({"id": 999})
         assert result is None
         assert get_silent_user.fail() is None
 

--- a/tests/unit/test_transactions.py
+++ b/tests/unit/test_transactions.py
@@ -38,9 +38,9 @@ class TestTransactWrite:
             get_user.prepare_delete({"id": 1}),
         ])
 
-        assert get_user.find({"id": 1}) is None
-        assert get_user.find({"id": 2}).first_name == "Jane"
-        assert get_order.find({"id": 100}).total == 50
+        assert get_user.get_item({"id": 1}) is None
+        assert get_user.get_item({"id": 2}).first_name == "Jane"
+        assert get_order.get_item({"id": 100}).total == 50
 
     def test_transact_write_with_update(self, get_user, create_table, aws_mock):
         get_user.create({"id": 1, "first_name": "John", "email": "john@mail.com", "role": "admin"})
@@ -49,7 +49,7 @@ class TestTransactWrite:
             get_user.prepare_update({"id": 1}, {"first_name": "Jane"}),
         ])
 
-        user = get_user.find({"id": 1})
+        user = get_user.get_item({"id": 1})
         assert user.first_name == "Jane"
 
 


### PR DESCRIPTION
## Summary

- **Breaking change**: renomeia o classmethod `find(dict)` para `get_item(dict)` — busca por chave primária via `GetItem`
- **Novo método de instância `find(expression, **values)`**: API expressiva e unificada para query e scan com expression strings e placeholders (`:nome`). Suporta todos os operadores (`=`, `<>`, `<`, `<=`, `>`, `>=`, `begins_with`, `contains`, `in`, `between`, `exists`, `not_exists`, `attribute_type`) e conectores lógicos (`AND`, `OR`, `AND NOT`, `OR NOT`)
- **Novo parser `parse_expression()`** em `utils.py`: tokeniza, valida e resolve placeholders da expression string
- Atualiza `find_or_fail` para usar `get_item` internamente
- Bump de versão para `1.3.0`

### Exemplos de migração

```python
# Antes (v1.2.x)
user = User.find({"id": 1})
users = User().and_where("role", "admin").index("role-index").fetch(True)

# Depois (v1.3.0)
user = User.get_item({"id": 1})
users = User().find("role = :r", r="admin").index("role-index").fetch(True)
```

## Test plan

- [x] Testes do parser (`test_parse_expression.py`): operadores básicos, between, unários, conectores, erros de validação
- [x] Testes do `get_item` e novo `find` (`test_get_item.py`): scan all, query por key, múltiplas condições, begins_with, between, chaining
- [x] Todos os testes existentes migrados de `find({})` para `get_item({})`
- [x] Suite completa: 222 testes passando

🤖 Generated with [Claude Code](https://claude.com/claude-code)