### PR TITLE
fix(dynolayer): validate before auto id increment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Todas as mudanças relevantes do DynoLayer serão documentadas neste arquivo.
 
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e o projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR/).
 
+## [1.3.3] - 2026-04-13
+
+### Fixed
+
+- **Auto ID numérico**: Corrigida a ordem de execução nos métodos `create()`, `save()` e `batch_create()` para validar campos obrigatórios **antes** de incrementar o contador na tabela de controle. Anteriormente, se a validação falhasse (ex: campo requerido faltante), o ID auto incremente já havia sido consumido sem que o registro fosse salvo.
+
 ## [1.3.2] - 2026-04-13
 
 ### Fixed

--- a/dynolayer/dynolayer.py
+++ b/dynolayer/dynolayer.py
@@ -214,8 +214,8 @@ class DynoLayer(CrudMixin):
                 if key in instance.fillable():
                     instance._data[key] = value
 
-            instance.__apply_auto_id()
             instance.__validate_required_fields()
+            instance.__apply_auto_id()
 
             if instance._timestamps:
                 instance._data["created_at"] = instance._get_current_timestamp(instance._timestamp_format)
@@ -238,21 +238,6 @@ class DynoLayer(CrudMixin):
             ref_instance = cls()
             instances = []
 
-            # Pre-generate numeric IDs in a single atomic call
-            numeric_ids = None
-            if ref_instance._auto_id == "numeric":
-                items_needing_id = []
-                pk_field = ref_instance._partition_keys[0]
-                for data in items:
-                    if pk_field not in data or data.get(pk_field) is None:
-                        items_needing_id.append(True)
-                    else:
-                        items_needing_id.append(False)
-                count = sum(items_needing_id)
-                if count > 0:
-                    numeric_ids = ref_instance.__generate_numeric_id_batch(count)
-
-            numeric_id_index = 0
             for data in items:
                 instance = cls()
 
@@ -260,6 +245,23 @@ class DynoLayer(CrudMixin):
                     if key in instance.fillable():
                         instance._data[key] = value
 
+                instance.__validate_required_fields()
+                instances.append(instance)
+
+            # Pre-generate numeric IDs in a single atomic call
+            numeric_ids = None
+            if ref_instance._auto_id == "numeric":
+                pk_field = ref_instance._partition_keys[0]
+                items_needing_id = [
+                    pk_field not in inst._data or inst._data.get(pk_field) is None
+                    for inst in instances
+                ]
+                count = sum(items_needing_id)
+                if count > 0:
+                    numeric_ids = ref_instance.__generate_numeric_id_batch(count)
+
+            numeric_id_index = 0
+            for instance in instances:
                 if numeric_ids is not None:
                     pk_field = instance._partition_keys[0]
                     if pk_field not in instance._data or instance._data.get(pk_field) is None:
@@ -268,13 +270,9 @@ class DynoLayer(CrudMixin):
                 else:
                     instance.__apply_auto_id()
 
-                instance.__validate_required_fields()
-
                 if instance._timestamps:
                     instance._data["created_at"] = instance._get_current_timestamp(instance._timestamp_format)
                     instance._data["updated_at"] = instance._get_current_timestamp(instance._timestamp_format)
-
-                instances.append(instance)
 
             safe_items = [inst.__safe() for inst in instances]
             cls()._batch_put(safe_items)
@@ -436,6 +434,7 @@ class DynoLayer(CrudMixin):
     def save(self, condition=None) -> bool:
         self._last_error = None
         try:
+            self.__validate_required_fields()
             self.__apply_auto_id()
             self.__validate_required_fields(self._partition_keys)
             keys = {key: self.data()[key] for key in self._partition_keys}

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as file:
 
 setup(
     name='dynolayer',
-    version='1.3.2',
+    version='1.3.3',
     license='MIT License',
     packages=['dynolayer'],
     install_requires=[],

--- a/tests/unit/test_auto_id.py
+++ b/tests/unit/test_auto_id.py
@@ -3,7 +3,7 @@ import re
 import boto3
 import pytest
 from dynolayer.dynolayer import DynoLayer
-from dynolayer.exceptions import InvalidArgumentException, AutoIdException
+from dynolayer.exceptions import InvalidArgumentException, AutoIdException, ValidationException
 
 
 # --- Fixtures ---
@@ -228,6 +228,37 @@ class TestAutoIdNumeric:
         assert orders[0].id == 999
         assert orders[1].id == 1
         assert orders[2].id == 2
+
+    def test_create_validation_error_does_not_increment_counter(self, get_order_numeric, create_table_num_pk, create_sequences_table, aws_mock):
+        with pytest.raises(ValidationException):
+            get_order_numeric.create({"status": "pending"})  # missing required "total"
+
+        order = get_order_numeric.create({"total": 100, "status": "pending"})
+        assert order.id == 1
+
+    def test_save_validation_error_does_not_increment_counter(self, get_order_numeric, create_table_num_pk, create_sequences_table, aws_mock):
+        order_bad = get_order_numeric()
+        order_bad.status = "pending"
+        with pytest.raises(ValidationException):
+            order_bad.save()  # missing required "total"
+
+        order = get_order_numeric()
+        order.total = 100
+        order.status = "pending"
+        order.save()
+        assert order.id == 1
+
+    def test_batch_create_validation_error_does_not_increment_counter(self, get_order_numeric, create_table_num_pk, create_sequences_table, aws_mock):
+        with pytest.raises(ValidationException):
+            get_order_numeric.batch_create([
+                {"total": 100, "status": "pending"},
+                {"status": "pending"},  # missing required "total"
+            ])
+
+        orders = get_order_numeric.batch_create([
+            {"total": 200, "status": "shipped"},
+        ])
+        assert orders[0].id == 1
 
 
 # --- Validation Tests ---


### PR DESCRIPTION
## Summary

- Corrige o bug onde o auto ID numérico incrementava o contador na tabela de controle **antes** de validar campos obrigatórios. Se a validação falhasse (ex: campo requerido faltante), o ID era consumido sem que o registro fosse persistido.
- Reordena `__validate_required_fields()` para antes de `__apply_auto_id()` em `create()`, `save()` e `batch_create()`.
- Adiciona 3 testes que garantem que o counter não incrementa em caso de falha de validação.
- Bump de versão para **1.3.3**.

## Test plan

- [x] 230/230 testes passando (0 regressões)
- [x] Novo teste: `test_create_validation_error_does_not_increment_counter`
- [x] Novo teste: `test_save_validation_error_does_not_increment_counter`
- [x] Novo teste: `test_batch_create_validation_error_does_not_increment_counter`

🤖 Generated with [Claude Code](https://claude.com/claude-code)